### PR TITLE
Add Schoenfeld residual plot (dup of survival:::plot.cox.zph)

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -8,10 +8,12 @@ export(
 	"make.survfit.plot",
 	"make.survival.plot",
 	"make.survival.plot.ternary",
-	"schoenfeld.residual.plots"
+	"schoenfeld.residual.plots",
+	"create.schoenfeld.plot"
 	);
+S3method(plot,cox.zph);
 importFrom("grDevices", "dev.cur", "dev.off", "ps.options", "tiff");
 importFrom("graphics", "abline", "plot", "title");
 importFrom("stats", "C", "contr.treatment", "pchisq", "t.test");
-importFrom("utils", "read.table", "write.table"); 
+importFrom("utils", "read.table", "write.table");
 import ("BoutrosLab.plotting.general", "BoutrosLab.prognosticsignature.general", "BoutrosLab.statistics.general", "BoutrosLab.statistics.survival", "BoutrosLab.utilities", lattice,survival);

--- a/R/plot.cox.zph.R
+++ b/R/plot.cox.zph.R
@@ -1,0 +1,231 @@
+# Clone of survival:::plot.cox.zph but for BPG
+plot.cox.zph.bpg <- function(
+    x,
+    resid=TRUE,
+    se=TRUE,
+    df=4,
+    nsmo=40,
+    var,
+    lty=1:2,
+    col=1,
+    lwd=1,
+    hr = FALSE,
+    xlab.label = 'Time (transformation)',
+    ylab.label = expression(bold(beta~'(t) for <var>')),
+    ...
+    ) {
+    xx <- x$x
+    yy <- x$y
+    df <- max(df)     # in case df is a vector
+    nvar <- ncol(yy)
+    pred.x <- seq(from=min(xx), to=max(xx), length=nsmo)
+    temp <- c(pred.x, xx)
+    lmat <- splines::ns(temp, df=df, intercept=TRUE)
+    pmat <- lmat[1:nsmo,]       # for prediction
+    xmat <- lmat[-(1:nsmo),]
+    if (!is.logical(hr)) stop('hr parameter must be TRUE/FALSE')
+
+    if (missing(ylab.label)) {
+        if (hr) {
+            ylab.label <- paste0('HR(t) for ', dimnames(yy)[[2]])
+        } else {
+            ylab.label <- paste0('\u03b2(t) for ', dimnames(yy)[[2]])
+        }
+    }
+    if (missing(xlab.label)) {
+        xlab.label <- sprintf('Time (%s transform)', x$transform);
+        }
+
+    if (missing(var)) {
+        var <- 1:nvar
+        }
+    else {
+        if (is.character(var)) var <- match(var, dimnames(yy)[[2]])
+        if  (any(is.na(var)) || max(var)>nvar || min(var) <1)
+            stop('Invalid variable requested')
+        }
+
+    # Figure out a 'good' set of x-axis labels.  Find 8 equally spaced
+    #    values on the 'transformed' axis.  Then adjust until they correspond
+    #    to rounded 'true time' values.  Avoid the edges of the x axis, or
+    #    approx() may give a missing value
+    if (x$transform == 'log') {
+        xx <- exp(xx)
+        pred.x <- exp(pred.x)
+        }
+    else if (x$transform != 'identity') {
+        xtime <- x$time;
+        indx <- !duplicated(xx);  #avoid a warning message in R
+        apr1  <- approx(
+            x = xx[indx],
+            y = xtime[indx],
+            xout = seq(min(xx), max(xx), length=17)[2*(1:8)]
+            );
+        temp <- signif(apr1$y,2)
+        apr2  <- approx(xtime[indx], xx[indx], temp)
+        xaxisval <- apr2$y
+        xaxislab <- rep('',8)
+        for (i in 1:8) xaxislab[i] <- format(temp[i])
+        }
+    col <- rep(col, length=2)
+    lwd <- rep(lwd, length=2)
+    lty <- rep(lty, length=2)
+
+    # Now, finally do the work
+    rtn.plots <- sapply(var, function(i) {
+        #   Since release 3.1-6, yy can have missing values.  If a covariate is
+        # constant within a stratum then it's Shoenfeld residual is identially
+        # zero for all observations in that stratum.  These 'structural zeros'
+        # are marked with an NA.  They contain no information and should not
+        # by plotted.  Thus we need to do the spline fit one stratum at a time.
+        y <- yy[,i]
+        keep <- !is.na(y)
+        if (!all(keep)) y <- y[keep]
+
+        qmat <- qr(xmat[keep,])
+        if (qmat$rank < df) {
+            warning('spline fit is singular, variable ', i, ' skipped')
+            next
+        }
+
+        yhat <- pmat %*% qr.coef(qmat, y)
+        if (resid) yr <-range(yhat, y)
+        else       yr <-range(yhat)
+
+        if (se) {
+            bk <- backsolve(qmat$qr[1:df, 1:df], diag(df))
+            xtx <- bk %*% t(bk)
+            seval <- ((pmat%*% xtx) *pmat) %*% rep(1, df)
+
+            temp <- 2* sqrt(x$var[i,i]*seval)
+            yup <- yhat + temp
+            ylow<- yhat - temp
+            yr <- range(yr, yup, ylow)
+            }
+
+            plotpar <- list(...);
+
+            yaxis.log <- FALSE;
+            if (hr) {
+                y <- exp(y);
+                yr <- exp(yr);
+                yhat <- exp(yhat);
+                yup <- exp(yup);
+                ylow <- exp(ylow);
+                # Not sure I understand fully the log y-scale for BPG or lattice
+                # This *should* be
+                # yaxis.log <- exp(1);
+            }
+
+            # x-axis log works fine
+            xaxis.log <- if(x$transform == 'log') exp(1) else FALSE;
+
+            if (x$transform=='identity') {
+                plot.data <- data.frame(
+                    x = range(xx),
+                    y = range(yr)
+                    )
+                zph.plot <- create.scatterplot(
+                    formula = y ~ x,
+                    data = plot.data,
+                    type = 'n',
+                    ylab.label = ylab.label,
+                    xlab.label = xlab.label,
+                    yaxis.log = yaxis.log,
+                    ...
+                    )
+            } else {
+                plot.data <- data.frame(
+                    x = range(xx[keep]),
+                    y = yr
+                    )
+                if (is.null(plotpar$xat) && is.null(plotpar$xaxis.lab)) {
+                    zph.plot <- create.scatterplot(
+                        formula = y ~ x,
+                        data = plot.data,
+                        type = 'n',
+                        xaxis.log = xaxis.log,
+                        yaxis.log = yaxis.log,
+                        ylab.label = ylab.label,
+                        xlab.label = xlab.label,
+                        xat = xaxisval,
+                        xaxis.lab = xaxislab,
+                        ...
+                        )
+                    } else {
+                    zph.plot <- create.scatterplot(
+                        formula = y ~ x,
+                        data = plot.data,
+                        type = 'n',
+                        xaxis.log = xaxis.log,
+                        yaxis.log = yaxis.log,
+                        ylab.label = ylab.label,
+                        xlab.label = xlab.label,
+                        ...
+                        )
+                    }
+                }
+
+                if (resid) {
+                    points.data <- data.frame(
+                        x = xx[keep],
+                        y = y
+                        )
+                    zph.plot <- zph.plot + create.scatterplot(
+                        formula = y ~ x,
+                        data = points.data,
+                        xaxis.log = xaxis.log,
+                        yaxis.log = yaxis.log,
+                        ...
+                        )
+                    }
+
+                pred.data <- data.frame(
+                    y = yhat,
+                    yupper = yup,
+                    ylower = ylow,
+                    x = pred.x
+                    )
+
+                zph.plot <- zph.plot + create.scatterplot(
+                    formula = y ~ x,
+                    data = pred.data,
+                    type = 'l',
+                    xaxis.log = xaxis.log,
+                    yaxis.log = yaxis.log,
+                    lty=lty[1],
+                    col=col[1],
+                    lwd=lwd[1]
+                    )
+
+                if (se) {
+                    zph.plot <- zph.plot + create.scatterplot(
+                        formula = yupper ~ x,
+                        data = pred.data,
+                        type = 'l',
+                        xaxis.log = xaxis.log,
+                        yaxis.log = yaxis.log,
+                        lty=lty[2],
+                        col=col[2],
+                        lwd=lwd[2]
+                        )
+                    zph.plot <- zph.plot + create.scatterplot(
+                        formula = ylower ~ x,
+                        data = pred.data,
+                        type = 'l',
+                        xaxis.log = xaxis.log,
+                        yaxis.log = yaxis.log,
+                        lty=lty[2],
+                        col=col[2],
+                        lwd=lwd[2]
+                        )
+                    }
+        return(zph.plot);
+    }, simplify = FALSE, USE.NAMES = TRUE)
+
+    if (length(rtn.plots) == 1) {
+        return(rtn.plots[[1]]);
+        } else {
+        return(rtn.plots);
+        }
+    }

--- a/R/plot.cox.zph.R
+++ b/R/plot.cox.zph.R
@@ -1,5 +1,25 @@
-# Clone of survival:::plot.cox.zph but for BPG
-plot.cox.zph.bpg <- function(
+#' Clone of survival:::plot.cox.zph but for BPG
+#'
+#' @param resid a logical value, if TRUE the residuals are included on the plot, as well as the smooth fit.
+#' @param se a logical value, if TRUE, confidence bands at two standard errors will be added.
+#' @param df the degrees of freedom for the fitted natural spline, df=2 leads to a linear fit.
+#' @param nsmo	number of points to use for the lines
+#' @param var the set of variables for which plots are desired. By default, plots are produced in turn for each variable of a model. Selection of a single variable allows other features to be added to the plot, e.g., a horizontal line at zero or a main title. This has been superseded by a subscripting method; see the example below.
+#' @param hr if TRUE, label the y-axis using the estimated hazard ratio rather than the estimated coefficient. (The plot does not change, only the axis label.)
+#' @param xlab.label label for the x-axis of the plot
+#' @param ylab.label optional label for the y-axis of the plot. If missing a default label is provided. This can be a vector of labels.
+#' @param lty
+#' @param col
+#' @param lwd
+#' @param abline.h
+#' @param abline.col
+#' @param abline.lwd
+#' @param abline.lty
+#' @param ... additional graphical arguments passed to the create.scatterplot function.
+#'
+#' @export create.schoenfeld.plot
+#' @export
+plot.cox.zph <- create.schoenfeld.plot <- function(
     x,
     resid=TRUE,
     se=TRUE,
@@ -10,6 +30,10 @@ plot.cox.zph.bpg <- function(
     col=1,
     lwd=1,
     hr = FALSE,
+    abline.h = 0,
+    abline.col = 'darkgrey',
+    abline.lwd = 1,
+    abline.lty = 2,
     xlab.label = 'Time (transformation)',
     ylab.label = expression(bold(beta~'(t) for <var>')),
     ...
@@ -129,7 +153,7 @@ plot.cox.zph.bpg <- function(
                     formula = y ~ x,
                     data = plot.data,
                     type = 'n',
-                    ylab.label = ylab.label,
+                    ylab.label = ylab.label[[i]],
                     xlab.label = xlab.label,
                     yaxis.log = yaxis.log,
                     ...
@@ -146,7 +170,7 @@ plot.cox.zph.bpg <- function(
                         type = 'n',
                         xaxis.log = xaxis.log,
                         yaxis.log = yaxis.log,
-                        ylab.label = ylab.label,
+                        ylab.label = ylab.label[[i]],
                         xlab.label = xlab.label,
                         xat = xaxisval,
                         xaxis.lab = xaxislab,
@@ -159,7 +183,7 @@ plot.cox.zph.bpg <- function(
                         type = 'n',
                         xaxis.log = xaxis.log,
                         yaxis.log = yaxis.log,
-                        ylab.label = ylab.label,
+                        ylab.label = ylab.label[[i]],
                         xlab.label = xlab.label,
                         ...
                         )
@@ -176,6 +200,10 @@ plot.cox.zph.bpg <- function(
                         data = points.data,
                         xaxis.log = xaxis.log,
                         yaxis.log = yaxis.log,
+                        abline.h = abline.h,
+                        abline.col = abline.col,
+                        abline.lwd = abline.lwd,
+                        abline.lty = abline.lty,
                         ...
                         )
                     }


### PR DESCRIPTION
# Description
Implements `survival:::plot.cox.zph` but with BPG. A few minor change like x-axis includes transformation type.

Initial code was copied from: https://github.com/therneau/survival/blob/master/R/plot.cox.zph.R and most of the code is intact. Some of the code does not meet lab standards yet. Some of the code could be refactored to separate functions (like computing SE).


# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [x] This PR does NOT contain [PHI](https://ohrpp.research.ucla.edu/hipaa/) or germline genetic data.  A repo may need to be deleted if such data is uploaded. Disclosing PHI is a [major problem](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m).
- [x] This PR does NOT contain molecular files, compressed files, output files such as images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other non-plain-text files.  To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example.
- [x] I have read the [code review guidelines](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List).
- [x] I have set up or verified the `main` branch protection rule following the [github standards](https://confluence.mednet.ucla.edu/pages/viewpage.action?spaceKey=BOUTROSLAB&title=GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.
- [x] The name of the branch is meaningful and well formatted following the [standards](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
- [x] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

<!-- 
Admin/maintainer: please edit the remaining sections as needed for your project repo.  
Then commit/push the changes so everyone uses this template for future PRs.

For example, if your project is a `pipeline`, then create a pipeline testing results section.

If your project is a general data analysis project, then you may want to require testing results
in each PR to help prevent creating new bugs.
-->

## Examples

``` r
library(BoutrosLab.plotting.survival);

# Example from ?survival:::plot.cox.zph
vfit <- coxph(Surv(time,status) ~ trt + factor(celltype) +
              karno + age, data=veteran, x=TRUE);
temp <- cox.zph(vfit);

par(mfrow = c(2, 2));
survival:::plot.cox.zph(temp);
```

![temp_survival](https://github.com/uclahs-cds/public-R-BoutrosLab-plotting-survival/assets/1639487/59759503-bfb2-4cb9-bd35-2758ed6043db)

```r
create.multipanelplot(
    plot.objects = create.schoenfeld.plot(
        temp,
        ylab.cex = 1.75,
        xlab.cex = 1.75
        ),
    layout.width = 2,
    layout.height = 2,
    filename = 'temp.png',
    resolution = 300,
    width = 12,
    height = 10
    );
```

![temp](https://github.com/uclahs-cds/public-R-BoutrosLab-plotting-survival/assets/1639487/1bb9e2bb-df91-440c-bbd2-b3f595652252)

X-axis is labeled according to transformation.

```r
temp2 <- cox.zph(vfit, transform = 'rank');
plot(temp2, var = 'age');
```

![image](https://github.com/uclahs-cds/public-R-BoutrosLab-plotting-survival/assets/1639487/af0fe904-fb11-4c7c-9531-4de262107cb9)
